### PR TITLE
Adding support for defaultdict, list of types supported by library is…

### DIFF
--- a/safepickle/tests/test_safepickle.py
+++ b/safepickle/tests/test_safepickle.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime, timedelta
 from tempfile import mkstemp
 from unittest.mock import Mock
@@ -21,6 +22,9 @@ class TestSafepickle(TestCase):
                 self._float = 1.0
                 self._datetime = datetime(year=1, month=1, day=1)
                 self._timedelta = timedelta(days=1)
+                self._defaultdict_int = defaultdict(int)
+                self._defaultdict_list = defaultdict(list)
+                self._defaultdict_set = defaultdict(set)
 
         instance = ClassToPersist()
 
@@ -91,7 +95,10 @@ class TestSafepickle(TestCase):
             "_int": 1,
             "_float": 1.0,
             "_datetime": datetime(year=1, month=1, day=1),
-            "_timedelta": timedelta(days=1)
+            "_timedelta": timedelta(days=1),
+            "_defaultdict_int": defaultdict(int),
+            "_defaultdict_list": defaultdict(list),
+            "_defaultdict_set": defaultdict(set)
         }
         obj_as_bytes = dumps(obj)
         from_obj = loads(obj_as_bytes)
@@ -110,7 +117,10 @@ class TestSafepickle(TestCase):
             "_int": 1,
             "_float": 1.0,
             "_datetime": datetime(year=1, month=1, day=1),
-            "_timedelta": timedelta(days=1)
+            "_timedelta": timedelta(days=1),
+            "_defaultdict_int": defaultdict(int),
+            "_defaultdict_list": defaultdict(list),
+            "_defaultdict_set": defaultdict(set)
         }
         fd, temp_path = mkstemp()
         try:

--- a/safepickle/types/bytearray.py
+++ b/safepickle/types/bytearray.py
@@ -13,3 +13,6 @@ class ByteArrayType(EncoderDecoderType):
 
     def decode(self, obj):
         return bytearray(obj['__bytearray__'])
+
+    def get_type(self):
+        return bytearray

--- a/safepickle/types/bytes.py
+++ b/safepickle/types/bytes.py
@@ -13,3 +13,6 @@ class BytesType(EncoderDecoderType):
 
     def decode(self, obj):
         return bytes(obj['__bytes__'])
+
+    def get_type(self):
+        return bytes

--- a/safepickle/types/datetime_.py
+++ b/safepickle/types/datetime_.py
@@ -21,3 +21,6 @@ class DatetimeType(EncoderDecoderType):
 
     def decode(self, obj):
         return datetime(**obj['__datetime__'])
+
+    def get_type(self):
+        return datetime

--- a/safepickle/types/defaultdict.py
+++ b/safepickle/types/defaultdict.py
@@ -1,0 +1,25 @@
+from collections import defaultdict
+
+from .interface import EncoderDecoderType
+
+
+class DefaultDictType(EncoderDecoderType):
+    def can_encode(self, obj):
+        return isinstance(obj, defaultdict)
+
+    def encode(self, obj, encode_fn):
+        from .manager import TypesManager
+        return {"__defaultdict__":
+                [(encode_fn(k), encode_fn(v)) for k, v in obj.items()],
+                "type": TypesManager.get_str_type(obj.default_factory)}
+
+    def can_decode(self, obj):
+        return isinstance(obj, dict) and '__defaultdict__' in obj
+
+    def decode(self, obj):
+        from .manager import TypesManager
+        obj_as_dict = {k: v for (k, v) in obj['__defaultdict__']}
+        return defaultdict(TypesManager.get_type(obj['type']), obj_as_dict)
+
+    def get_type(self):
+        return defaultdict

--- a/safepickle/types/dict.py
+++ b/safepickle/types/dict.py
@@ -22,3 +22,6 @@ class DictType(EncoderDecoderType):
         except ValueError:
             # attempt to load it as legacy version used to
             return obj['__dct__']
+
+    def get_type(self):
+        return dict

--- a/safepickle/types/instance.py
+++ b/safepickle/types/instance.py
@@ -14,3 +14,6 @@ class InstanceType(EncoderDecoderType):
     def decode(self, obj):
         # no special decoding needed
         pass
+
+    def get_type(self):
+        return object

--- a/safepickle/types/interface.py
+++ b/safepickle/types/interface.py
@@ -38,3 +38,8 @@ class EncoderDecoderType(object):
             obj: instance to decode 
         """
         raise NotImplementedError
+
+    def get_type(self):
+        """ Provides supported type
+        """
+        raise NotImplementedError

--- a/safepickle/types/list.py
+++ b/safepickle/types/list.py
@@ -14,3 +14,6 @@ class ListType(EncoderDecoderType):
     def decode(self, obj):
         # no special decoding needed
         pass
+
+    def get_type(self):
+        return list

--- a/safepickle/types/manager.py
+++ b/safepickle/types/manager.py
@@ -1,3 +1,4 @@
+from .defaultdict import DefaultDictType
 from .set import SetType
 from .tuple import TupleType
 from .dict import DictType
@@ -16,6 +17,7 @@ class _TypesManager(object):
         self._types = [
             SetType(),
             TupleType(),
+            DefaultDictType(),
             DictType(),
             ListType(),
             DatetimeType(),
@@ -27,6 +29,29 @@ class _TypesManager(object):
 
     def get_types(self):
         return self._types
+
+    def get_str_type(self, raw_type):
+        """ Provides the string name for a given type
+        """
+        for type_ in (bool, int, float, str):
+            if type_ == raw_type:
+                return type_.__name__
+
+        for type_ in self._types:
+            if type_.get_type() == raw_type:
+                return type_.__class__.__name__
+
+    def get_type(self, str_type):
+        """ Provides a type from its string name
+        """
+        for type_ in (bool, int, float, str):
+            if str_type == type_.__name__:
+                return type_
+
+        for type_ in self._types:
+            if type_.__class__.__name__ == str_type:
+                return type_.get_type()
+
 
 # Singleton instance to _TypesManager
 TypesManager = _TypesManager()

--- a/safepickle/types/set.py
+++ b/safepickle/types/set.py
@@ -13,3 +13,6 @@ class SetType(EncoderDecoderType):
 
     def decode(self, obj):
         return set(obj['__set__'])
+
+    def get_type(self):
+        return set

--- a/safepickle/types/tests/test_defaultdict.py
+++ b/safepickle/types/tests/test_defaultdict.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+
+from datetime import timedelta, datetime
+
+from safepickle.types.defaultdict import DefaultDictType
+from safepickle.encoding import encode, decode
+
+from unittest import TestCase
+
+
+class TestDefaultDict(TestCase):
+
+    def test_defaultdict(self):
+        _types = [int, bool, float, str,
+                  bytearray, bytes, datetime, defaultdict, dict,
+                  list, set, timedelta, tuple]
+        for _type in _types:
+            obj = defaultdict(_type)
+            type_ = DefaultDictType()
+            encoding = type_.encode(obj, encode)
+            decoding = decode(encoding)
+            self.assertDictEqual(obj, decoding)
+            self.assertEqual(obj.default_factory, decoding.default_factory)

--- a/safepickle/types/tests/test_manager.py
+++ b/safepickle/types/tests/test_manager.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from collections import defaultdict
+
+from safepickle.types import TypesManager
+from datetime import timedelta, datetime
+
+
+class TestManager(TestCase):
+
+    def test_get_type(self):
+        types = [int, bool, float, str,
+                 bytearray, bytes, datetime, defaultdict, dict,
+                 list, set, timedelta, tuple]
+        for type1 in types:
+            type2 = TypesManager.get_type(TypesManager.get_str_type(type1))
+            self.assertEqual(type1, type2)

--- a/safepickle/types/timedelta.py
+++ b/safepickle/types/timedelta.py
@@ -18,3 +18,6 @@ class TimedeltaType(EncoderDecoderType):
 
     def decode(self, obj):
         return timedelta(**obj['__timedelta__'])
+
+    def get_type(self):
+        return timedelta

--- a/safepickle/types/tuple.py
+++ b/safepickle/types/tuple.py
@@ -13,3 +13,6 @@ class TupleType(EncoderDecoderType):
 
     def decode(self, obj):
         return tuple(obj['__tuple__'])
+
+    def get_type(self):
+        return tuple


### PR DESCRIPTION
…: int, bool, float, str,

bytearray, bytes, datetime, defaultdict, dict, list, set, timedelta, tuple, Note: 'defaultdict' is limited to refer to these same types where appropriate